### PR TITLE
Add support for Set's of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ const item = {
   map: { key: 'val', nested: ['list'] },
   null: null,
   num: 42,
+  set: new Set(['a', 'a', 'b']),
   string: 'strung',
   undef: undefined
 }
@@ -73,6 +74,7 @@ const Item = {
   },
   null: { NULL: true },
   num: { N: '42' },
+  set: { SS: ['a', 'b'] },
   string: { S: 'strung' }
 }
 ```
@@ -109,13 +111,14 @@ expect(parse(serialize(item))).to.eql(item)
 
 ### Caveat emptor
 
-By design, `dynamoo` only supports the following basic data types for attributes:
+By design, `dynamoo` only supports the following data types for attributes:
 
   - `Array`
   - `Boolean`
   - `null`
   - `Number`
   - `Object`
+  - `Set` (of strings)
   - `String`
 
-If you want to use any other fancier types, such as `Map`, `Set`, etc., then this library won't work for you.
+If you want to use any other fancier types, such as `Map`, or `Set` of numbers, etc., then you may need to do some additional work.  Or file an issue.  :wink:

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const {
-  assoc, compose, constant, identity, map, mapObj, reduceObj
+  assoc, constant, identity, map, mapObj, partialRight, reduceObj
 } = require('tinyfunk')
 
 const parseEach = (acc, val, type) =>
@@ -35,7 +35,7 @@ const serializeOne = val => {
 }
 
 const serializeSet =
-  compose(map(String), Array.from)
+  partialRight(Array.from, [ String ])
 
 const serialize =
   reduceObj(serializeEach, {})

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const {
-  assoc, constant, identity, map, mapObj, reduceObj
+  assoc, compose, constant, identity, map, mapObj, reduceObj
 } = require('tinyfunk')
 
 const parseEach = (acc, val, type) =>
@@ -7,6 +7,9 @@ const parseEach = (acc, val, type) =>
 
 const parseOne =
   reduceObj(parseEach, null)
+
+const parseSet = val =>
+  new Set(val)
 
 const parse =
   mapObj(parseOne)
@@ -17,7 +20,8 @@ const getTypes = {
   M:    { xfrm: parse },
   N:    { xfrm: JSON.parse },
   NULL: { xfrm: constant(null) },
-  S:    { xfrm: identity }
+  S:    { xfrm: identity },
+  SS:   { xfrm: parseSet }
 }
 
 const serializeEach = (attrs, val, key) =>
@@ -30,6 +34,9 @@ const serializeOne = val => {
   return { [ label ]: xfrm(val) }
 }
 
+const serializeSet =
+  compose(map(String), Array.from)
+
 const serialize =
   reduceObj(serializeEach, {})
 
@@ -39,13 +46,21 @@ const putTypes = {
   null:    { label: 'NULL', xfrm: constant(true) },
   number:  { label: 'N',    xfrm: JSON.stringify },
   object:  { label: 'M',    xfrm: serialize },
+  set:     { label: 'SS',   xfrm: serializeSet },
   string:  { label: 'S',    xfrm: identity }
 }
-const typeOf = val =>
-  Array.isArray(val)
-    ? 'array'
-    : val === null
-      ? 'null'
-      : typeof val
+
+const typeOf = val => {
+  switch (true) {
+    case Array.isArray(val):
+      return 'array'
+    case val instanceof Set:
+      return 'set'
+    case val === null:
+      return 'null'
+    default:
+      return typeof val
+  }
+}
 
 module.exports = { parse, serialize }

--- a/test.js
+++ b/test.js
@@ -11,6 +11,7 @@ describe('dynamoo', () => {
     map: { key: 'val', nested: ['list'] },
     null: null,
     num: 42,
+    set: new Set(['a', 'a', 'b']),
     string: 'strung',
     undef: undefined
   }
@@ -34,6 +35,7 @@ describe('dynamoo', () => {
     },
     null: { NULL: true },
     num: { N: '42' },
+    set: { SS: ['a', 'b'] },
     string: { S: 'strung' }
   }
 


### PR DESCRIPTION
![dilbert](https://assets.amuniversal.com/d8b0bf309d44012f2fe500163e41dd5b)

Because I want to use [string sets](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.ADD) in DynamoDB.